### PR TITLE
Add invite links that autofill room/password

### DIFF
--- a/public/js/codenames.js
+++ b/public/js/codenames.js
@@ -409,7 +409,10 @@ function extractFromFragment(fragment, toExtract) {
   let vars = fragment.substring(1).split('&');
   for (let i = 0; i < vars.length; i++) {
     var pair = vars[i].split('=');
-    if (decodeURIComponent(pair[0]) == toExtract) {
+    if (pair.length !== 2) {
+      continue;
+    }
+    if (decodeURIComponent(pair[0]) === toExtract) {
         return decodeURIComponent(pair[1]);
     }
   }

--- a/public/js/codenames.js
+++ b/public/js/codenames.js
@@ -87,7 +87,6 @@ joinEnter.onclick = () => {
     room:joinRoom.value,
     password:joinPassword.value
   })
-  updateFragment();
 }
 // User Creates Room
 joinCreate.onclick = () => {      
@@ -96,7 +95,6 @@ joinCreate.onclick = () => {
     room:joinRoom.value,
     password:joinPassword.value
   })
-  updateFragment();
 }
 // User Leaves Room
 leaveRoom.onclick = () => {       
@@ -212,6 +210,7 @@ socket.on('joinResponse', (data) =>{        // Response to joining room
     joinDiv.style.display = 'none'
     gameDiv.style.display = 'block'
     joinErrorMessage.innerText = ''
+    updateFragment();
   } else joinErrorMessage.innerText = data.msg
 })
 
@@ -220,6 +219,7 @@ socket.on('createResponse', (data) =>{      // Response to creating room
     joinDiv.style.display = 'none'
     gameDiv.style.display = 'block'
     joinErrorMessage.innerText = ''
+    updateFragment();
   } else joinErrorMessage.innerText = data.msg
 })
 

--- a/public/js/codenames.js
+++ b/public/js/codenames.js
@@ -87,6 +87,7 @@ joinEnter.onclick = () => {
     room:joinRoom.value,
     password:joinPassword.value
   })
+  updateFragment();
 }
 // User Creates Room
 joinCreate.onclick = () => {      
@@ -95,6 +96,7 @@ joinCreate.onclick = () => {
     room:joinRoom.value,
     password:joinPassword.value
   })
+  updateFragment();
 }
 // User Leaves Room
 leaveRoom.onclick = () => {       
@@ -412,6 +414,13 @@ function extractFromFragment(fragment, toExtract) {
     }
   }
   return '';
+}
+
+function updateFragment() {
+  let room = joinRoom.value;
+  let password = joinPassword.value;
+  let fragment =  'room=' + encodeURIComponent(room) + '&password=' + encodeURIComponent(password);
+  window.location.hash = fragment;
 }
 
 // Client Side UI Elements

--- a/public/js/codenames.js
+++ b/public/js/codenames.js
@@ -73,6 +73,10 @@ buttonModeTimed.disabled = false;
 buttonRoleGuesser.disabled = true;
 buttonRoleSpymaster.disabled = false;
 
+// Autofill room and password from query fragment
+joinRoom.value = extractFromFragment(window.location.hash, 'room');
+joinPassword.value = extractFromFragment(window.location.hash, 'password');
+
 
 // UI Interaction with server
 ////////////////////////////////////////////////////////////////////////////
@@ -397,6 +401,17 @@ function updatePlayerlist(players){
       blueTeam.appendChild(li)
     }
   }
+}
+
+function extractFromFragment(fragment, toExtract) {
+  let vars = fragment.substring(1).split('&');
+  for (let i = 0; i < vars.length; i++) {
+    var pair = vars[i].split('=');
+    if (decodeURIComponent(pair[0]) == toExtract) {
+        return decodeURIComponent(pair[1]);
+    }
+  }
+  return '';
 }
 
 // Client Side UI Elements


### PR DESCRIPTION
Copied from Joooop#5

> Hopefully this will make inviting players to a game easier, as they now only need to click a link and fill in their nick name. The implementation uses the query fragment to store/retrieve the room/password strings.
> 
> This lacks some bells and whistles that would be nice to have but require more disruptive code changes:
> 
>     * A simpler UX for users joining a room that hides the room/password fields and the "create room" button (all they need to interact with are nickname and "enter room")
> 
>     * A button to copy the invite link to clipboard
> 
>     * Better consistency guarantees on the values used by `updateFragment()`
>       
>       * It's possible for a user to edit the text boxes between clicking join and the server responding, which would cause the fragment to be incorrect
>       * Unlikely to occur in practice
>       * Easiest fix is to have the server echo room/password back to the client